### PR TITLE
JDK version update

### DIFF
--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -36,9 +36,9 @@
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
     <jettyVersion>12.0.1</jettyVersion>
     <spotless.check.skip>true</spotless.check.skip>
-    <!-- Jetty http3 is JDK17+ -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <!-- JDK14 seems to be compatible with both, jetty http3 dependencies and maven 3.9.x extensions API -->
+    <maven.compiler.source>14</maven.compiler.source>
+    <maven.compiler.target>14</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
@@ -206,8 +206,8 @@ final class HttpTransporter extends AbstractTransporter {
             response = request.method(method).headers(httpFields -> {
                 if (bodyContent != null) {
                     httpFields.add(HttpHeader.CONTENT_TYPE, bodyContent.getContentType());
-                    if (task instanceof PutTask putTask) {
-                        final long dataLength = putTask.getDataLength();
+                    if (task instanceof PutTask) {
+                        final long dataLength = ((PutTask)task).getDataLength();
                         if (dataLength > 0) {
                             httpFields.add(HttpHeader.CONTENT_LENGTH, dataLength);
                         }


### PR DESCRIPTION
JDK14 seems to be compatible with both, jetty http3 dependencies and maven 3.9.x extensions API.