### PR TITLE
Artipie http3 test

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build it with Maven
         run: |
           cd mvn-resolver-transport-http3
-          mvn -B verify
+          mvn -B verify -P docker-build
   xcop-linter:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd mvn-resolver-transport-http3
           export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
-          mvn deploy -Partipie,publish,sonatype,gpg-sign -DskipITs --errors
+          mvn deploy -Psonatype,gpg-sign -DskipITs --errors
       - name: Create Github Release
         id: create_release
         uses: actions/create-release@v1

--- a/mvn-resolver-transport-http3/Dockerfile
+++ b/mvn-resolver-transport-http3/Dockerfile
@@ -1,0 +1,56 @@
+# Ubuntu 16.04
+# Oracle Java 21 64 bit
+# Maven 3.9.5
+
+FROM ubuntu:22.04
+
+# this is a non-interactive automated build - avoid some warning messages
+ENV DEBIAN_FRONTEND noninteractive
+
+# update dpkg repositories
+RUN apt-get update
+
+# install wget
+RUN apt-get install -y wget
+
+# get maven 3.3.9
+RUN wget --no-verbose -O /tmp/apache-maven-3.9.5.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz
+
+# install maven
+RUN tar xzf /tmp/apache-maven-3.9.5.tar.gz -C /opt/
+RUN ln -s /opt/apache-maven-3.9.5 /opt/maven
+RUN ln -s /opt/maven/bin/mvn /usr/local/bin
+RUN rm -f /tmp/apache-maven-3.9.5.tar.gz
+ENV MAVEN_HOME /opt/maven
+
+# remove download archive files
+RUN apt-get clean
+
+# set shell variables for java installation
+ENV java_version 21
+ENV filename jdk-21_linux-x64_bin.tar.gz
+ENV downloadlink https://download.oracle.com/java/21/latest/$filename
+
+# download java, accepting the license agreement
+RUN wget --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" -O /tmp/$filename $downloadlink
+
+# unpack java
+RUN mkdir /opt/java-oracle/ && mkdir /opt/java-oracle/jdk21/ && tar -zxf /tmp/$filename -C /opt/java-oracle/jdk21/ --strip-components 1
+ENV JAVA_HOME /opt/java-oracle/jdk21
+ENV PATH $JAVA_HOME/bin:$PATH
+
+# configure symbolic links for the java and javac executables
+RUN update-alternatives --install /usr/bin/java java $JAVA_HOME/bin/java 20000 && update-alternatives --install /usr/bin/javac javac $JAVA_HOME/bin/javac 20000
+
+# check maven
+RUN mvn --version
+
+RUN mkdir /usr/plugin/ && mkdir /usr/plugin/src/ && mkdir /usr/plugin/src/main/
+COPY src/main /usr/plugin/src/main/
+COPY pom.xml /usr/plugin/pom.xml
+
+WORKDIR "/usr/plugin"
+
+RUN mvn install -DskipTests
+
+CMD [""]

--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -40,7 +40,17 @@
     <maven.compiler.source>14</maven.compiler.source>
     <maven.compiler.target>14</maven.compiler.target>
   </properties>
-
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.10.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -83,12 +93,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>
@@ -98,24 +102,6 @@
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-test-util</artifactId>
       <version>1.9.16</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <version>9.4.51.v20230217</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-      <version>9.4.51.v20230217</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-      <version>9.4.51.v20230217</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -178,8 +164,30 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <version>1.18.3</version>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.19.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mockserver</artifactId>
+      <version>1.19.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-platform.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -19,14 +19,9 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.artipie</groupId>
-    <artifactId>ppom</artifactId>
-    <version>1.1.0</version>
-  </parent>
   <artifactId>maven-resolver-transport-http3</artifactId>
   <groupId>com.artipie.maven.resolver</groupId>
-  <version>0.0.2</version>
+  <version>1.0-SNAPSHOT</version>
 
   <name>Artipie Maven Artifact Resolver Transport HTTP3</name>
   <description>A transport implementation for repositories using HTTP3.</description>
@@ -36,6 +31,7 @@
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
     <jettyVersion>12.0.1</jettyVersion>
     <spotless.check.skip>true</spotless.check.skip>
+    <docker.image.name>http3-resolver</docker.image.name>
     <!-- JDK14 seems to be compatible with both, jetty http3 dependencies and maven 3.9.x extensions API -->
     <maven.compiler.source>14</maven.compiler.source>
     <maven.compiler.target>14</maven.compiler.target>
@@ -45,7 +41,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.10.0</version>
+        <version>5.10.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -68,10 +64,14 @@
       <version>1.9.14</version>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.16.0</version>
-      <scope>runtime</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-reload4j</artifactId>
+      <version>2.0.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -87,39 +87,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>5.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-test-util</artifactId>
-      <version>1.9.16</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>2.0.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
-      <scope>test</scope>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.http3</groupId>
@@ -163,80 +133,171 @@
       <version>${jettyVersion}</version>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-test-util</artifactId>
+      <version>1.9.16</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>1.19.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>mockserver</artifactId>
-      <version>1.19.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-platform.version}</version>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+<profiles>
+  <profile>
+    <id>docker-build</id>
+    <activation>
+      <activeByDefault>false</activeByDefault>
+    </activation>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>dockerfile-maven-plugin</artifactId>
+          <version>1.4.13</version>
+          <executions>
+            <execution>
+              <id>default</id>
+              <goals>
+                <goal>build</goal>
+                <goal>push</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <repository>${docker.image.name}</repository>
+            <tag>${project.version}</tag>
+            <dockerfile>Dockerfile</dockerfile>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+  <profile>
+    <id>sonatype</id>
+    <build>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>jar-sources</id>
+              <configuration>
+                <forceCreation>true</forceCreation>
+              </configuration>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>jar-javadoc</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.13</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>oss.sonatype.org</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <description>${project.version}</description>
+            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>deploy-sonatype</id>
+              <phase>deploy</phase>
+              <goals>
+                <goal>deploy</goal>
+                <goal>release</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+  <profile>
+    <id>gpg-sign</id>
+    <activation>
+      <property>
+        <name>gpg.keyname</name>
+      </property>
+    </activation>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.1.0</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+              <configuration>
+                <gpgArguments>
+                  <arg>--pinentry-mode</arg>
+                  <arg>loopback</arg>
+                </gpgArguments>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+  </profile>
+</profiles>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.eclipse.sisu</groupId>
-        <artifactId>sisu-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-<!--          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>-->
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-      <groupId>com.diffplug.spotless</groupId>
-      <artifactId>spotless-maven-plugin</artifactId>
-      <configuration>
-      </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <source>${maven.compiler.source}</source>
         </configuration>
       </plugin>
       <plugin>
@@ -248,25 +309,6 @@
           </includes>
         </configuration>
       </plugin>
-      <!--package to jar with dependencies and use original name-->
-      <!--<plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <finalName>${project.build.finalName}</finalName>
-          <appendAssemblyId>false</appendAssemblyId>
-        </configuration>
-      </plugin>-->
     </plugins>
   </build>
 </project>

--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -302,12 +302,16 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*IT.class</include>
-          </includes>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
@@ -19,40 +19,61 @@
 package com.artipie.aether.transport.http3;
 
 import com.artipie.aether.transport.http3.checksum.ChecksumExtractor;
-import org.eclipse.aether.ConfigurationProperties;
-import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.repository.AuthenticationContext;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.spi.connector.transport.*;
-import org.eclipse.aether.transfer.NoTransporterException;
-import org.eclipse.aether.util.ConfigUtils;
-import org.eclipse.aether.util.FileUtils;
-import org.eclipse.jetty.client.*;
-import org.eclipse.jetty.http.*;
-import org.eclipse.jetty.http3.client.HTTP3Client;
-import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
-
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import static java.util.Objects.requireNonNull;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.aether.ConfigurationProperties;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.AuthenticationContext;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.transport.AbstractTransporter;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportTask;
+import org.eclipse.aether.transfer.NoTransporterException;
+import org.eclipse.aether.util.ConfigUtils;
+import org.eclipse.aether.util.FileUtils;
+import org.eclipse.jetty.client.BasicAuthentication;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpRequestException;
+import org.eclipse.jetty.client.HttpResponseException;
+import org.eclipse.jetty.client.InputStreamRequestContent;
+import org.eclipse.jetty.client.InputStreamResponseListener;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Response;
+import org.eclipse.jetty.http.HttpFieldPreEncoder;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.PreEncodedHttpField;
+import org.eclipse.jetty.http3.client.HTTP3Client;
+import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 
 /**
  * A transporter for HTTP/HTTPS.
  */
 final class HttpTransporter extends AbstractTransporter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpTransporter.class);
 
     private final Map<String, ChecksumExtractor> checksumExtractors;
 
@@ -63,14 +84,15 @@ final class HttpTransporter extends AbstractTransporter {
     private final URI baseUri;
 
     private final HttpClient client;
+    private final int connectTimeout;
 
     private String[] authInfo = null;
 
     HttpTransporter(
             Map<String, ChecksumExtractor> checksumExtractors,
             RemoteRepository repository,
-            RepositorySystemSession session)
-        throws Exception {
+            RepositorySystemSession session
+    ) throws Exception {
 
         forceLoadHttp3Support();
 
@@ -105,12 +127,14 @@ final class HttpTransporter extends AbstractTransporter {
             session,
             ConfigurationProperties.HTTPS_SECURITY_MODE_DEFAULT,
             ConfigurationProperties.HTTPS_SECURITY_MODE + "." + repository.getId(),
-            ConfigurationProperties.HTTPS_SECURITY_MODE);
-        int connectTimeout = ConfigUtils.getInteger(
+            ConfigurationProperties.HTTPS_SECURITY_MODE
+        );
+        this.connectTimeout = ConfigUtils.getInteger(
             session,
             ConfigurationProperties.DEFAULT_CONNECT_TIMEOUT,
             ConfigurationProperties.CONNECT_TIMEOUT + "." + repository.getId(),
-            ConfigurationProperties.CONNECT_TIMEOUT);
+            ConfigurationProperties.CONNECT_TIMEOUT
+        );
 
         HTTP3Client h3Client = new HTTP3Client();
         HttpClientTransportOverHTTP3 transport = new HttpClientTransportOverHTTP3(h3Client);
@@ -118,8 +142,9 @@ final class HttpTransporter extends AbstractTransporter {
         this.client.setFollowRedirects(true);
         this.client.setConnectTimeout(connectTimeout);
         this.client.start();
-        h3Client.getClientConnector().getSslContextFactory()
-            .setTrustAll(httpsSecurityMode.equals(ConfigurationProperties.HTTPS_SECURITY_MODE_INSECURE));
+        h3Client.getClientConnector().getSslContextFactory().setTrustAll(
+            httpsSecurityMode.equals(ConfigurationProperties.HTTPS_SECURITY_MODE_INSECURE)
+        );
     }
 
     @Override
@@ -137,20 +162,22 @@ final class HttpTransporter extends AbstractTransporter {
 
     @Override
     protected void implGet(GetTask task) throws Exception {
-        ContentResponse response = this.makeRequest(HttpMethod.GET, task, null);
+        final Pair<InputStream, HttpFields> response = this.makeRequest(HttpMethod.GET, task, null);
         final boolean resume = false;
         final File dataFile = task.getDataFile();
-        final byte[] content = response.getContent();
+        long length = Long.parseLong(
+            Optional.ofNullable(response.getValue().get(HttpHeader.CONTENT_LENGTH)).orElse("0")
+        );
         if (dataFile == null) {
-            try (final InputStream is = new ByteArrayInputStream(content)) {
-                utilGet(task, is, true, content.length, resume);
-                extractChecksums(response, task);
+            try (final InputStream is = response.getKey()) {
+                utilGet(task, is, true, length, resume);
+                extractChecksums(response.getValue(), task);
             }
         } else {
             try (FileUtils.CollocatedTempFile tempFile = FileUtils.newTempFile(dataFile.toPath())) {
                 task.setDataFile(tempFile.getPath().toFile());
-                try (final InputStream is = new ByteArrayInputStream(content)) {
-                    utilGet(task, is, true, content.length, resume);
+                try (final InputStream is = response.getKey()) {
+                    utilGet(task, is, true, length, resume);
                 }
                 tempFile.move();
             } finally {
@@ -158,7 +185,7 @@ final class HttpTransporter extends AbstractTransporter {
             }
         }
         if (task.getDataFile() != null) {
-            final String lastModifiedHeader = response.getHeaders().get(HttpHeader.LAST_MODIFIED);
+            final String lastModifiedHeader = response.getValue().get(HttpHeader.LAST_MODIFIED);
             if (lastModifiedHeader != null) {
                 final DateFormat lastModifiedFormat = new SimpleDateFormat(
                     "EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US
@@ -192,7 +219,9 @@ final class HttpTransporter extends AbstractTransporter {
         AuthenticationContext.close(proxyAuthContext);
     }
 
-    private ContentResponse makeRequest(HttpMethod method, TransportTask task, Request.Content bodyContent) {
+    private Pair<InputStream, HttpFields> makeRequest(
+        HttpMethod method, TransportTask task, Request.Content bodyContent
+    ) {
         final String url = this.baseUri.resolve(task.getLocation()).toString();
         System.err.printf("Custom HttpTransporter.makeRequest() called! Method: %s; URL: %s%n", method.toString(), url);
         if (this.authInfo != null) {
@@ -200,10 +229,10 @@ final class HttpTransporter extends AbstractTransporter {
                 new BasicAuthentication.BasicResult(this.baseUri, this.authInfo[0], this.authInfo[1])
             );
         }
-        final Request request = this.client.newRequest(url);
-        final ContentResponse response;
         try {
-            response = request.method(method).headers(httpFields -> {
+            InputStreamResponseListener listener = new InputStreamResponseListener();
+            this.client.newRequest(url).method(method).headers(
+                httpFields -> {
                 if (bodyContent != null) {
                     httpFields.add(HttpHeader.CONTENT_TYPE, bodyContent.getContentType());
                     if (task instanceof PutTask) {
@@ -213,17 +242,20 @@ final class HttpTransporter extends AbstractTransporter {
                         }
                     }
                 }
-            }).body(bodyContent).send();
+            }).body(bodyContent).send(listener);
+            final Response response = listener.get(this.connectTimeout, TimeUnit.MILLISECONDS);
+            if (response.getStatus() >= 300) {
+                System.err.println("Response status not success " + response.getStatus());
+                throw new HttpResponseException(Integer.toString(response.getStatus()), response);
+            }
+            return new ImmutablePair<>(listener.getInputStream(), response.getHeaders());
         } catch (Exception ex) {
-            throw new HttpRequestException(ex.getMessage(), request);
+            System.err.println("Error on request " + ex.getMessage());
+            throw new HttpRequestException(ex.getMessage(), this.client.newRequest(url));
         }
-        if (response.getStatus() >= 300) {
-            throw new HttpResponseException(Integer.toString(response.getStatus()), response);
-        }
-        return response;
     }
 
-    private void extractChecksums(ContentResponse response, GetTask task) {
+    private void extractChecksums(HttpFields response, GetTask task) {
         for (Map.Entry<String, ChecksumExtractor> extractorEntry : checksumExtractors.entrySet()) {
             Map<String, String> checksums = extractorEntry.getValue().extractChecksums(response);
             if (checksums != null) {

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/ChecksumExtractor.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/ChecksumExtractor.java
@@ -20,6 +20,7 @@ package com.artipie.aether.transport.http3.checksum;
 
 import org.eclipse.jetty.client.ContentResponse;
 import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
 
 /**
  * A component extracting included checksums from response of artifact request.
@@ -30,5 +31,5 @@ public abstract class ChecksumExtractor {
     /**
      * Tries to extract checksums from response headers, if present, otherwise returns {@code null}.
      */
-    public abstract Map<String, String> extractChecksums(ContentResponse response);
+    public abstract Map<String, String> extractChecksums(HttpFields response);
 }

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/Nexus2ChecksumExtractor.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/Nexus2ChecksumExtractor.java
@@ -20,6 +20,7 @@ package com.artipie.aether.transport.http3.checksum;
 
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -37,10 +38,10 @@ public class Nexus2ChecksumExtractor extends ChecksumExtractor {
     public static final String NAME = "nexus2";
 
     @Override
-    public Map<String, String> extractChecksums(ContentResponse response) {
+    public Map<String, String> extractChecksums(HttpFields headers) {
         // Nexus-style, ETag: "{SHA1{d40d68ba1f88d8e9b0040f175a6ff41928abd5e7}}"
 
-        HttpField field = response.getHeaders().getField(HttpHeader.ETAG);
+        HttpField field = headers.getField(HttpHeader.ETAG);
         String etag = field == null? null: field.getValue();
 
         if (etag != null) {

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/XChecksumChecksumExtractor.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/checksum/XChecksumChecksumExtractor.java
@@ -25,6 +25,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
 
 /**
  * A component extracting {@code x-} non-standard style checksums from response headers.
@@ -44,7 +45,7 @@ public class XChecksumChecksumExtractor extends ChecksumExtractor {
     public static final String NAME = "x-checksum";
 
     @Override
-    public Map<String, String> extractChecksums(ContentResponse response) {
+    public Map<String, String> extractChecksums(HttpFields response) {
         String value;
         HashMap<String, String> result = new HashMap<>();
         // Central style: x-checksum-sha1: c74edb60ca2a0b57ef88d9a7da28f591e3d4ce7b
@@ -74,8 +75,8 @@ public class XChecksumChecksumExtractor extends ChecksumExtractor {
         return result.isEmpty() ? null : result;
     }
 
-    private String extractChecksum(ContentResponse response, String name) {
-        HttpField header = response.getHeaders().getField(name);
+    private String extractChecksum(HttpFields response, String name) {
+        HttpField header = response.getField(name);
         return header == null ? null : header.getValue();
     }
 }

--- a/mvn-resolver-transport-http3/src/main/resources/log4j.properties
+++ b/mvn-resolver-transport-http3/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootLogger=INFO, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %d %t %c - %m%n
+
+log4j2.formatMsgNoLookups=True
+
+log4j.logger.com.artipie=DEBUG

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -17,6 +17,21 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.MountableFile;
 
+/**
+ * This test uses two docker containers:<p>
+ * 1) {@link ArtipieHTTP3IT#artipie} is container with latest artipie version running on ubuntu 22.04 and java 21<p>
+ * 2) {@link ArtipieHTTP3IT#mavenClient} is ubuntu 22.04 based container with this plugin built with maven 3.9.5 under java 21,
+ * see ./Dockerfile<p>
+ *
+ * The containers are connected via docker {@link Network} with alias 'artipie'. Artipie container
+ * runs HTTP3 maven-proxy repository available at <code>https://artipie:8091/my-maven-proxy/</code>.
+ * <p>
+ * Test maven project {@code ./resources/com/example/maven-http3} which uses this plugin is added to
+ * {@link ArtipieHTTP3IT#mavenClient} and built with maven settings
+ * {@code ./resources/com/example/maven-http3/maven-settings.xml}. The dependencies of this project
+ * are obtained from Artipie via HTTP3.
+ *
+ */
 public class ArtipieHTTP3IT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtipieHTTP3IT.class);
@@ -28,9 +43,6 @@ public class ArtipieHTTP3IT {
     private final Consumer<OutputFrame> artipieLog =
         new Slf4jLogConsumer(LoggerFactory.getLogger(this.getClass())).withPrefix("ARTIPIE");
 
-    /**
-     * Container network.
-     */
     private Network net;
 
     @BeforeEach

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -82,8 +82,8 @@ public class ArtipieHTTP3IT {
             res,
             Matchers.stringContainsInOrder(
                 "BUILD SUCCESS",
-                "https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
-                "https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
+                "Request over HTTP3 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
+                "Request over HTTP3 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
             )
         );
     }

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -1,0 +1,50 @@
+package com.artipie.aether.transport.http3;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
+
+public class ArtipieHTTP3IT {
+
+    /**
+     * Container.
+     */
+    private GenericContainer<?> mavenClient;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void init() {
+        this.mavenClient = new GenericContainer<>("maven:3.6.3-jdk-11")
+            .withCommand("tail", "-f", "/dev/null")
+            .withWorkingDirectory("/w");
+        this.mavenClient.start();
+    }
+
+    @Test
+    void resolvesDependencies() throws IOException, InterruptedException {
+        this.putClasspathResourceToClient("maven-http3/maven-settings.xml", "/w/settings.xml");
+        this.putClasspathResourceToClient("maven-http3/pom.xml", "/w/pom.xml");
+        final Container.ExecResult exec =
+            this.mavenClient.execInContainer("mvn", "-s", "settings.xml", "dependency:resolve");
+        System.out.println(exec.getStdout() + exec.getStderr());
+        MatcherAssert.assertThat(
+            "Resolved", exec.getExitCode() == 0
+        );
+    }
+
+
+    private void putClasspathResourceToClient(final String res, final String path) {
+        final MountableFile file = MountableFile.forClasspathResource(res);
+        this.mavenClient.copyFileToContainer(file, path);
+    }
+
+}

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -1,46 +1,87 @@
 package com.artipie.aether.transport.http3;
 
 import java.io.IOException;
-import java.nio.file.Path;
+import java.util.function.Consumer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.MountableFile;
 
 public class ArtipieHTTP3IT {
 
-    /**
-     * Container.
-     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtipieHTTP3IT.class);
+
     private GenericContainer<?> mavenClient;
 
-    @TempDir
-    Path tmp;
+    private GenericContainer<?> artipie;
+
+    private final Consumer<OutputFrame> artipieLog =
+        new Slf4jLogConsumer(LoggerFactory.getLogger(this.getClass())).withPrefix("ARTIPIE");
+
+    /**
+     * Container network.
+     */
+    private Network net;
 
     @BeforeEach
-    void init() {
-        this.mavenClient = new GenericContainer<>("maven:3.6.3-jdk-11")
+    void init() throws IOException, InterruptedException {
+        this.net = Network.newNetwork();
+        this.artipie =  new GenericContainer<>("artipie/artipie-ubuntu:1.0-SNAPSHOT")
+            .withNetwork(this.net)
+            .withNetworkAliases("artipie")
+            .withLogConsumer(this.artipieLog)
+            .withClasspathResourceMapping(
+                "artipie.yaml", "/etc/artipie/artipie.yml", BindMode.READ_ONLY
+            )
+            .withClasspathResourceMapping(
+                "my-maven-proxy.yaml", "/var/artipie/repo/my-maven-proxy.yaml", BindMode.READ_ONLY
+            )
+            .withWorkingDirectory("/w");
+        this.mavenClient = new GenericContainer<>("http3-resolver:1.0-SNAPSHOT")
+            .withNetwork(this.net)
             .withCommand("tail", "-f", "/dev/null")
             .withWorkingDirectory("/w");
         this.mavenClient.start();
+        this.artipie.start();
+        this.mavenClient.execInContainer("sleep", "5");
     }
 
     @Test
     void resolvesDependencies() throws IOException, InterruptedException {
-        this.putClasspathResourceToClient("maven-http3/maven-settings.xml", "/w/settings.xml");
-        this.putClasspathResourceToClient("maven-http3/pom.xml", "/w/pom.xml");
-        final Container.ExecResult exec =
-            this.mavenClient.execInContainer("mvn", "-s", "settings.xml", "dependency:resolve");
-        System.out.println(exec.getStdout() + exec.getStderr());
+        this.putClasspathResourceToClient("com/example/maven-http3/maven-settings.xml", "/w/settings.xml");
+        this.putClasspathResourceToClient("com/example/maven-http3/pom.xml", "/w/pom.xml");
+        final Container.ExecResult exec = this.mavenClient.execInContainer(
+            "mvn", "install", "-s", "settings.xml", "-Daether.connector.https.securityMode=insecure"
+        );
+        String res = String.join("\n", exec.getStdout(), exec.getStderr());
+        LOGGER.info(res);
+        MatcherAssert.assertThat("Maven install is not successful", exec.getExitCode() == 0);
         MatcherAssert.assertThat(
-            "Resolved", exec.getExitCode() == 0
+            res,
+            Matchers.stringContainsInOrder(
+                "BUILD SUCCESS",
+                "https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
+                "https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
+            )
         );
     }
 
+    @AfterEach
+    void close() {
+        this.artipie.stop();
+        this.mavenClient.stop();
+        this.net.close();
+    }
 
     private void putClasspathResourceToClient(final String res, final String path) {
         final MountableFile file = MountableFile.forClasspathResource(res);

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -36,7 +36,7 @@ public class ArtipieHTTP3IT {
     @BeforeEach
     void init() throws IOException, InterruptedException {
         this.net = Network.newNetwork();
-        this.artipie =  new GenericContainer<>("artipie/artipie-ubuntu:1.0-SNAPSHOT")
+        this.artipie =  new GenericContainer<>("artipie/artipie-ubuntu:latest")
             .withNetwork(this.net)
             .withNetworkAliases("artipie")
             .withLogConsumer(this.artipieLog)

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
@@ -19,15 +19,14 @@ import org.eclipse.aether.spi.connector.transport.Transporter;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpRequestException;
-import org.eclipse.jetty.client.HttpResponseException;
 import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http3.client.HTTP3Client;
 import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -177,7 +176,7 @@ public class MavenResolverIT {
         assertArrayEquals(srcData, dstData);
     }
 
-    @BeforeClass
+    @BeforeAll
     @SuppressWarnings("deprecation")
     public static void prepare() throws IOException, InterruptedException {
         try {
@@ -204,7 +203,7 @@ public class MavenResolverIT {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void finish() {
         caddyProxy.stop();
         tempFile.delete();

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
@@ -1,5 +1,12 @@
 package com.artipie.aether.transport.http3;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.eclipse.aether.ConfigurationProperties;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
@@ -9,31 +16,29 @@ import org.eclipse.aether.spi.connector.transport.GetTask;
 import org.eclipse.aether.spi.connector.transport.PutTask;
 import org.eclipse.aether.spi.connector.transport.TransportListener;
 import org.eclipse.aether.spi.connector.transport.Transporter;
-import org.eclipse.jetty.client.*;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpRequestException;
+import org.eclipse.jetty.client.HttpResponseException;
+import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http3.client.HTTP3Client;
 import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
-import org.eclipse.jetty.io.Content;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.InternetProtocol;
 import org.testcontainers.containers.wait.strategy.ShellStrategy;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Testing transport via containerized Caddy http3 server in proxy mode.

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/MavenResolverIT.java
@@ -60,8 +60,8 @@ public class MavenResolverIT {
 
     @Test
     public void testTransporterAuthFail() {
-        HttpResponseException exception = assertThrows(
-            "Invalid exception thrown", HttpResponseException.class,
+        HttpRequestException exception = assertThrows(
+            "Invalid exception thrown", HttpRequestException.class,
             () -> testTransporter("https://demo1:demo1@localhost:7444/maven2")
         );
         assertEquals("401", exception.getMessage());
@@ -69,8 +69,8 @@ public class MavenResolverIT {
 
     @Test
     public void testTransporterAnonAuthFail() {
-        HttpResponseException exception = assertThrows(
-            "Invalid exception thrown", HttpResponseException.class,
+        HttpRequestException exception = assertThrows(
+            "Invalid exception thrown", HttpRequestException.class,
             () -> testTransporter("https://localhost:7444/maven2")
         );
         assertEquals("401", exception.getMessage());
@@ -94,11 +94,10 @@ public class MavenResolverIT {
 
     @Test()
     public void testTransporterInvalidUrl() {
-        HttpRequestException exception = assertThrows(
+        assertThrows(
             "Invalid exception thrown", HttpRequestException.class,
             () -> testTransporter("https://localhost:7440/maven2")
         );
-        assertEquals("java.net.SocketTimeoutException: connect timeout", exception.getMessage());
     }
 
     private byte[] testTransporter(final String repo) throws Exception {

--- a/mvn-resolver-transport-http3/src/test/resources/artipie.yaml
+++ b/mvn-resolver-transport-http3/src/test/resources/artipie.yaml
@@ -1,0 +1,6 @@
+meta:
+  storage:
+    type: fs
+    path: /var/artipie/repo
+  credentials:
+    - type: env

--- a/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/maven-settings.xml
+++ b/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/maven-settings.xml
@@ -23,12 +23,18 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
 <settings>
-    <mirrors>
-        <mirror>
+    <profiles>
+        <profile>
             <id>artipie-proxy</id>
-            <name>Local proxy of central repo</name>
-            <url>http://localhost:90548/my-maven-proxy/</url>
-            <mirrorOf>*</mirrorOf>
-        </mirror>
-    </mirrors>
+            <repositories>
+                <repository>
+                    <id>my-maven</id>
+                    <url>https://artipie:8091/my-maven-proxy/</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artipie-proxy</activeProfile>
+    </activeProfiles>
 </settings>

--- a/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/maven-settings.xml
+++ b/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/maven-settings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2020 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<settings>
+    <mirrors>
+        <mirror>
+            <id>artipie-proxy</id>
+            <name>Local proxy of central repo</name>
+            <url>http://localhost:90548/my-maven-proxy/</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/pom.xml
+++ b/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/pom.xml
@@ -33,34 +33,28 @@ SOFTWARE.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+
     <dependencies>
+
         <dependency>
-            <groupId>com.amihaiemil.web</groupId>
-            <artifactId>eo-yaml</artifactId>
-            <version>7.0.5</version>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.33</version>
         </dependency>
+
         <dependency>
-            <groupId>com.artipie</groupId>
-            <artifactId>http</artifactId>
-            <version>v1.2.20</version>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.1.0</version>
         </dependency>
-        <dependency>
-            <groupId>io.etcd</groupId>
-            <artifactId>jetcd-core</artifactId>
-            <version>0.5.4</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
+
     </dependencies>
     <build>
         <extensions>
             <extension>
                 <groupId>com.artipie.maven.resolver</groupId>
                 <artifactId>maven-resolver-transport-http3</artifactId>
-                <version>0.0.1</version>
+                <version>1.0-SNAPSHOT</version>
             </extension>
         </extensions>
     </build>

--- a/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/pom.xml
+++ b/mvn-resolver-transport-http3/src/test/resources/com/example/maven-http3/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2020 artipie.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>maven-http3</artifactId>
+    <version>0.1</version>
+    <packaging>jar</packaging>
+    <name>Pom with dependencies</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.amihaiemil.web</groupId>
+            <artifactId>eo-yaml</artifactId>
+            <version>7.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.artipie</groupId>
+            <artifactId>http</artifactId>
+            <version>v1.2.20</version>
+        </dependency>
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-core</artifactId>
+            <version>0.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>com.artipie.maven.resolver</groupId>
+                <artifactId>maven-resolver-transport-http3</artifactId>
+                <version>0.0.1</version>
+            </extension>
+        </extensions>
+    </build>
+
+</project>

--- a/mvn-resolver-transport-http3/src/test/resources/my-maven-proxy.yaml
+++ b/mvn-resolver-transport-http3/src/test/resources/my-maven-proxy.yaml
@@ -1,0 +1,13 @@
+repo:
+  type: maven-proxy
+  storage:
+    type: fs
+    path: /var/artipie/data
+  remotes:
+    - url: https://repo.maven.apache.org/maven2
+  port: 8091
+  http3: true # enable http3 mode for repository
+  http3_ssl:
+    jks:
+      path: /var/artipie/keystore.jks # path to jks file, not storage relative
+      password: secret


### PR DESCRIPTION
Added integration test for plugin and artipie, also:

- get rid of artipie ppom usage (I don't think it's appropriate here, will check release after merge)
- removed unused deps and plugins from pom, used modern junit version
- changed jetty http api usage to get response body as `InputStream` (via `InputStreamResponseListener`) instead of byte array after getting `buffering capacity exceeded` error for some heavy jar

