### PR TITLE
feat: use HTTP/1.1 on HTTP/3 fail

### DIFF
--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -25,7 +25,21 @@
 
   <name>Artipie Maven Artifact Resolver Transport HTTP3</name>
   <description>A transport implementation for repositories using HTTP3.</description>
-
+  <url>https://github.com/artipie/maven-resolver-http3-plugin</url>
+  <inceptionYear>2023</inceptionYear>
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>https://github.com/artipie/maven-resolver-http3-plugin/blob/master/LICENSE.txt</url>
+    </license>
+  </licenses>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/artipie/maven-resolver-http3-plugin/issues</url>
+  </issueManagement>
+  <scm>
+    <url>https://github.com/artipie/maven-resolver-http3-plugin</url>
+  </scm>
   <properties>
     <Automatic-Module-Name>com.artipie.maven.resolver.transport.http3</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>
@@ -130,6 +144,11 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-io</artifactId>
+      <version>${jettyVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
       <version>${jettyVersion}</version>
     </dependency>
     <dependency>

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.exception.UncheckedException;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -308,7 +309,7 @@ final class HttpTransporter extends AbstractTransporter {
                 "Request over %s error=%s: %s, method=%s, url=%s%n", version,
                 ex.getClass(), ex.getMessage(), method, url
             );
-            if (version == HttpVersion.HTTP_3) {
+            if (version == HttpVersion.HTTP_3 && ex instanceof TimeoutException) {
                 System.err.printf("Repeat request over HTTP/1.1 method=%s, url=%s%n", method, url);
                 return this.makeRequest(method, task, bodyContent, this.initOrGetHttpClient());
             }

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieHTTP3IT.java
@@ -82,8 +82,8 @@ public class ArtipieHTTP3IT {
             res,
             Matchers.stringContainsInOrder(
                 "BUILD SUCCESS",
-                "Request over HTTP3 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
-                "Request over HTTP3 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
+                "Request over HTTP/3.0 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
+                "Request over HTTP/3.0 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
             )
         );
     }

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/TransporterTest.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/TransporterTest.java
@@ -1,0 +1,126 @@
+package com.artipie.aether.transport.http3;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.aether.spi.connector.transport.GetTask;
+import org.eclipse.aether.spi.connector.transport.PeekTask;
+import org.eclipse.aether.spi.connector.transport.PutTask;
+import org.eclipse.aether.spi.connector.transport.TransportListener;
+import org.eclipse.aether.spi.connector.transport.Transporter;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TransporterTest {
+
+    private int port;
+
+    private Server server;
+
+    private CountDownLatch latch;
+
+    @BeforeEach
+    void init() throws Exception {
+        this.server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        server.addConnector(connector);
+        latch = new CountDownLatch(1);
+        this.server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception {
+                response.setStatus(200);
+                if ("GET".equals(request.getMethod())) {
+                    response.write(true, ByteBuffer.wrap(getCommonsJar()), Callback.NOOP);
+                } else {
+                    response.write(true, ByteBuffer.allocate(0), Callback.NOOP);
+                }
+                Content.Chunk chunk = request.read();
+                if (chunk.hasRemaining()) {
+                    MatcherAssert.assertThat(
+                        chunk.getByteBuffer().array(), new IsEqual<>(getCommonsJar())
+                    );
+                }
+                latch.countDown();
+                return false;
+            }
+        });
+        this.server.start();
+        this.port = connector.getLocalPort();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "https://repo.maven.apache.org/maven2/",
+        "https://oss.sonatype.org/content/repositories/releases/"
+    })
+    void performsRequestToCentral(final String url) throws Exception {
+        final byte[] data = this.getResource(url);
+        MatcherAssert.assertThat(data, new IsEqual<>(this.getCommonsJar()));
+    }
+
+    @Test
+    void getsResourceFromLocalhostViaHttp1() throws Exception {
+        final byte[] data = this.getResource(String.format("http://localhost:%d", this.port));
+        MatcherAssert.assertThat(data, new IsEqual<>(this.getCommonsJar()));
+    }
+
+    @Test
+    void performsHeadRequest() throws Exception {
+        final PeekTask task = new PeekTask(URI.create(MavenResolverIT.REMOTE_PATH));
+        try (final Transporter transporter = new HttpTransporterFactory().newInstance(
+            MavenResolverIT.newSession(),
+            MavenResolverIT.newRepo(String.format("http://localhost:%d", this.port))
+        )) {
+            transporter.peek(task);
+        }
+        MatcherAssert.assertThat("Head performed", latch.await(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    void performsPutRequest() throws Exception {
+        final PutTask task = new PutTask(URI.create(MavenResolverIT.REMOTE_PATH))
+            .setListener(new TransportListener() {});
+        try (final Transporter transporter = new HttpTransporterFactory().newInstance(
+            MavenResolverIT.newSession(),
+            MavenResolverIT.newRepo(String.format("http://localhost:%d", this.port))
+        )) {
+            transporter.put(task);
+        }
+        MatcherAssert.assertThat("Put performed", latch.await(1, TimeUnit.MINUTES));
+    }
+
+    @AfterEach
+    void close() throws Exception {
+        this.server.stop();
+        this.server.destroy();
+    }
+
+    private byte[] getResource(final String repo) throws Exception {
+        final GetTask task = new GetTask(URI.create(MavenResolverIT.REMOTE_PATH))
+            .setListener(new TransportListener() {});
+        try (final Transporter transporter = new HttpTransporterFactory()
+            .newInstance(MavenResolverIT.newSession(), MavenResolverIT.newRepo(repo))) {
+            transporter.get(task);
+        }
+        return task.getDataBytes();
+    }
+
+    byte[] getCommonsJar() throws IOException {
+        return getClass().getClassLoader().getResourceAsStream(MavenResolverIT.LOCAL_PATH).readAllBytes();
+    }
+
+}


### PR DESCRIPTION
part of #14 (check description)

Added HTTP/1.1 client along with clients initialization "on request", added simple test. IT test will be added letter. 

If request is done via not appropriate protocol version, `TimeoutException` is thrown and in this case we make request via HTTP/1.1. It will not be correct to re-request in any exception as http client can throw exception in the case of some not success status like 401.