### PR TITLE
fix: add developers into pom

### DIFF
--- a/mvn-resolver-transport-http3/pom.xml
+++ b/mvn-resolver-transport-http3/pom.xml
@@ -40,6 +40,28 @@
   <scm>
     <url>https://github.com/artipie/maven-resolver-http3-plugin</url>
   </scm>
+  <developers>
+    <developer>
+      <id>https://github.com/ChGen</id>
+      <name>Evgeny Chugunnyy</name>
+      <email>chgenn.x@gmail.com</email>
+      <organization>Artipie</organization>
+      <organizationUrl>https://www.artipie.com</organizationUrl>
+      <roles>
+        <role>maintainer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>https://github.com/olenagerasimova</id>
+      <name>Alena</name>
+      <email>olena.gerasimova@gmail.com</email>
+      <organization>Artipie</organization>
+      <organizationUrl>https://www.artipie.com</organizationUrl>
+      <roles>
+        <role>maintainer</role>
+      </roles>
+    </developer>
+  </developers>
   <properties>
     <Automatic-Module-Name>com.artipie.maven.resolver.transport.http3</Automatic-Module-Name>
     <Bundle-SymbolicName>${Automatic-Module-Name}</Bundle-SymbolicName>


### PR DESCRIPTION
Fixing [release error](https://github.com/artipie/maven-resolver-http3-plugin/actions/runs/7163975716/job/19503268468#step:9:15034):
```
Repository "comartipie-1737" failures
Error:    Rule "pom-staging" failures
Error:      * Invalid POM: /com/artipie/maven/resolver/maven-resolver-transport-http3/v0.0.6/maven-resolver-transport-http3-v0.0.6.pom: Developer information missing
```
