### PR TITLE
feat: logging via slf4j

### DIFF
--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
@@ -297,23 +297,23 @@ final class HttpTransporter extends AbstractTransporter {
             }).body(bodyContent).send(listener);
             final Response response = listener.get(this.connectTimeout, TimeUnit.MILLISECONDS);
             if (response.getStatus() >= 300) {
-                LOGGER.error(
+                LOGGER.debug(
                     "{} request error status {}, method={}, url={}",
                     version, response.getStatus(), method, url
                 );
                 throw new HttpResponseException(Integer.toString(response.getStatus()), response);
             }
-            LOGGER.info(
+            LOGGER.debug(
                 "{} request done, method={}, resp status={}, url={}", version, method, response.getStatus(), url
             );
             return new ImmutablePair<>(listener.getInputStream(), response.getHeaders());
         } catch (Exception ex) {
-            LOGGER.error(
+            LOGGER.debug(
                 "{} request error={}: {}, method={}, url={}", version,
                 ex.getClass(), ex.getMessage(), method, url
             );
             if (version == HttpVersion.HTTP_3 && ex instanceof TimeoutException) {
-                LOGGER.info("Repeat via HTTP/1.1 method={}, url={}", method, url);
+                LOGGER.debug("Repeat via HTTP/1.1 method={}, url={}", method, url);
                 return this.makeRequest(method, task, bodyContent, this.initOrGetHttpClient());
             }
             throw new HttpRequestException(ex.getMessage(), request);

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporter.java
@@ -73,11 +73,15 @@ import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http3.client.HTTP3Client;
 import org.eclipse.jetty.http3.client.transport.HttpClientTransportOverHTTP3;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A transporter for HTTP/HTTPS.
  */
 final class HttpTransporter extends AbstractTransporter {
+
+    static final Logger LOGGER = LoggerFactory.getLogger("http3.plugin");
 
     private final static Set<String> CENTRAL = Set.of(
         "repo.maven.apache.org",
@@ -114,7 +118,7 @@ final class HttpTransporter extends AbstractTransporter {
         }
         this.checksumExtractors = requireNonNull(checksumExtractors, "checksum extractors must not be null");
         try {
-            System.err.println("\tCustom HttpTransporter repo: " + repository.toString());
+            LOGGER.debug("Custom HttpTransporter repo: {}", repository);
             this.baseUri = new URI(repository.getUrl() + "/").normalize().parseServerAuthority();
             if (baseUri.isOpaque()) {
                 throw new URISyntaxException(repository.getUrl(), "URL must not be opaque");
@@ -293,24 +297,23 @@ final class HttpTransporter extends AbstractTransporter {
             }).body(bodyContent).send(listener);
             final Response response = listener.get(this.connectTimeout, TimeUnit.MILLISECONDS);
             if (response.getStatus() >= 300) {
-                System.err.printf(
-                    "Request over %s error status %s, method=%s, url=%s%n",
+                LOGGER.error(
+                    "{} request error status {}, method={}, url={}",
                     version, response.getStatus(), method, url
                 );
                 throw new HttpResponseException(Integer.toString(response.getStatus()), response);
             }
-            System.err.printf(
-                "Request over %s done, method=%s, resp status=%s, url=%s%n",
-                version, method, response.getStatus(), url
+            LOGGER.info(
+                "{} request done, method={}, resp status={}, url={}", version, method, response.getStatus(), url
             );
             return new ImmutablePair<>(listener.getInputStream(), response.getHeaders());
         } catch (Exception ex) {
-            System.err.printf(
-                "Request over %s error=%s: %s, method=%s, url=%s%n", version,
+            LOGGER.error(
+                "{} request error={}: {}, method={}, url={}", version,
                 ex.getClass(), ex.getMessage(), method, url
             );
             if (version == HttpVersion.HTTP_3 && ex instanceof TimeoutException) {
-                System.err.printf("Repeat request over HTTP/1.1 method=%s, url=%s%n", method, url);
+                LOGGER.info("Repeat via HTTP/1.1 method={}, url={}", method, url);
                 return this.makeRequest(method, task, bodyContent, this.initOrGetHttpClient());
             }
             throw new HttpRequestException(ex.getMessage(), request);
@@ -354,7 +357,7 @@ final class HttpTransporter extends AbstractTransporter {
      * @throws IllegalAccessException
      */
     private void forceLoadHttp3Support() throws NoSuchFieldException, IllegalAccessException {
-        System.err.println("Custom HttpTransporter.forceLoadHttp3Support() called!");
+        LOGGER.debug("Custom HttpTransporter.forceLoadHttp3Support() called!");
         // Checking http3 support is available (loaded)
         PreEncodedHttpField f = new PreEncodedHttpField("Host", "localhost");
         for (final HttpVersion v: HttpVersion.values()) {
@@ -369,47 +372,20 @@ final class HttpTransporter extends AbstractTransporter {
 
         // TODO: Force http3 initialization (HACK!)
         final ServiceLoader<HttpFieldPreEncoder> load = ServiceLoader.load(HttpFieldPreEncoder.class,PreEncodedHttpField.class.getClassLoader());
-        /*ServiceLoader<HttpFieldPreEncoder> load = null;
-        ClassLoader saveCl = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(PreEncodedHttpField.class.getClassLoader());
-            load = ServiceLoader.load(HttpFieldPreEncoder.class);
-        }finally {
-            Thread.currentThread().setContextClassLoader(saveCl);
-        }*/
-
-        /*System.err.println("\tCustom HttpTransporter ServiceLoader=" + load);
-        Stream<ServiceLoader.Provider<HttpFieldPreEncoder>> providerStream = TypeUtil.serviceProviderStream(load);
-        System.err.println("\tCustom HttpTransporter Stream<ServiceLoader.Provider<HttpFieldPreEncoder>> = " + providerStream);
-        ArrayList<Integer> calls = new ArrayList<>();
-        providerStream.forEach((provider) -> {
-            try {
-                calls.add(calls.size());
-                HttpFieldPreEncoder encoder = (HttpFieldPreEncoder)provider.get();
-                HttpVersion v = encoder.getHttpVersion();
-                System.err.println("\tCustom HttpTransporter HttpFieldPreEncoder: encoder=" + encoder + "; ver=" + v);
-            } catch (RuntimeException | Error var3) {
-                System.err.println("\tCustom HttpTransporter Error processing encoder: " + provider.get());
-            }
-        });
-        System.err.println("\tCustom HttpTransporter providerStream calls=" + calls.size());*/
-
         HashMap<HttpVersion, HttpFieldPreEncoder> encoders = new HashMap<>();
         for (HttpFieldPreEncoder val: load) {
-            //System.err.println("\tCustom HttpTransporter HttpFieldPreEncoder val=" + val);
+            LOGGER.debug("Custom HttpTransporter HttpFieldPreEncoder val={}", val);
             encoders.put(val.getHttpVersion(), val);
         }
 
         Field ff = PreEncodedHttpField.class.getDeclaredField("__encoders");
         ff.setAccessible(true);
-        String fldDescr = ff.get(null).toString();
-        //System.err.println("\tCustom HttpTransporter __encoders BEFORE: " + fldDescr + "; this=" + this);
         @SuppressWarnings("unchecked") EnumMap<HttpVersion, HttpFieldPreEncoder> obj = (EnumMap<HttpVersion, HttpFieldPreEncoder>)ff.get(null);
         if (encoders.containsKey(HttpVersion.HTTP_3) && !obj.containsKey(HttpVersion.HTTP_3)) {
-            //System.err.println("\tCustom HttpTransporter adding to __encoders: " + obj + "; this=" + this);
+            LOGGER.debug("Custom HttpTransporter adding to __encoders: {}, this = {}", obj, this);
             obj.put(HttpVersion.HTTP_3, encoders.get(HttpVersion.HTTP_3));
         }
-        //System.err.println("\tCustom HttpTransporter __encoders AFTER: " + obj + "; this=" + this);
+        LOGGER.debug("Custom HttpTransporter __encoders AFTER: {}; this={}", obj, this);
 
         // Rechecking http3 support is available (loaded)
         f = new PreEncodedHttpField("Host", "localhost");
@@ -420,7 +396,7 @@ final class HttpTransporter extends AbstractTransporter {
             } catch (Exception ex) {
                 len = -1;
             }
-            //System.err.println("\tCustom HttpTransporter PreEncodedHttpField v=" + v + "; len=" + len);
+            LOGGER.debug("Custom HttpTransporter PreEncodedHttpField v={}; len={}", v, len);
         }
     }
 }

--- a/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporterFactory.java
+++ b/mvn-resolver-transport-http3/src/main/java/com/artipie/aether/transport/http3/HttpTransporterFactory.java
@@ -90,7 +90,7 @@ public final class HttpTransporterFactory implements TransporterFactory {
             throws NoTransporterException {
         requireNonNull(session, "session cannot be null");
         requireNonNull(repository, "repository cannot be null");
-        System.err.println("Custom HttpTransporterFactory created!!!");
+        HttpTransporter.LOGGER.debug("Custom HttpTransporterFactory created!!!");
         try {
             return new HttpTransporter(extractors, repository, session);
         } catch (Exception e) {

--- a/mvn-resolver-transport-http3/src/main/resources/log4j.properties
+++ b/mvn-resolver-transport-http3/src/main/resources/log4j.properties
@@ -6,4 +6,5 @@ log4j.appender.CONSOLE.layout.ConversionPattern=[%p] %c - %m%n
 
 log4j2.formatMsgNoLookups=True
 
+log4j.logger.http3.plugin=DEBUG
 log4j.logger.com.artipie=DEBUG

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieAndLocalPluginHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieAndLocalPluginHTTP3IT.java
@@ -35,7 +35,7 @@ import org.testcontainers.utility.MountableFile;
  */
 public class ArtipieAndLocalPluginHTTP3IT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ArtipieAndLocalPluginHTTP3IT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger("ArtipieAndLocalPluginHTTP3IT");
 
     private GenericContainer<?> mavenClient;
 
@@ -82,9 +82,9 @@ public class ArtipieAndLocalPluginHTTP3IT {
         MatcherAssert.assertThat(
             res,
             Matchers.stringContainsInOrder(
-                "BUILD SUCCESS",
-                "Request over HTTP/3.0 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
-                "Request over HTTP/3.0 done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar"
+                "HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar",
+                "HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar",
+                "BUILD SUCCESS"
             )
         );
     }

--- a/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieAndLocalPluginHTTP3IT.java
+++ b/mvn-resolver-transport-http3/src/test/java/com/artipie/aether/transport/http3/ArtipieAndLocalPluginHTTP3IT.java
@@ -42,7 +42,8 @@ public class ArtipieAndLocalPluginHTTP3IT {
     private GenericContainer<?> artipie;
 
     private final Consumer<OutputFrame> artipieLog =
-        new Slf4jLogConsumer(LoggerFactory.getLogger(this.getClass())).withPrefix("ARTIPIE");
+        new Slf4jLogConsumer(LoggerFactory.getLogger("ArtipieAndLocalPluginHTTP3IT"))
+            .withPrefix("ARTIPIE");
 
     private Network net;
 
@@ -74,7 +75,7 @@ public class ArtipieAndLocalPluginHTTP3IT {
         this.putClasspathResourceToClient("com/example/maven-http3/maven-settings.xml", "/w/settings.xml");
         this.putClasspathResourceToClient("com/example/maven-http3/pom.xml", "/w/pom.xml");
         final Container.ExecResult exec = this.mavenClient.execInContainer(
-            "mvn", "install", "-s", "settings.xml", "-Daether.connector.https.securityMode=insecure"
+            "mvn", "install", "-X", "-s", "settings.xml", "-Daether.connector.https.securityMode=insecure"
         );
         String res = String.join("\n", exec.getStdout(), exec.getStderr());
         LOGGER.info(res);


### PR DESCRIPTION
Changed logging to slf4j logger. Now logs from maven build are the following:
```
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.pom (1.3 kB at 520 B/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j-site/2.33/args4j-site-2.33.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j-site/2.33/args4j-site-2.33.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j-site/2.33/args4j-site-2.33.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j-site/2.33/args4j-site-2.33.pom (4.4 kB at 7.4 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/kohsuke/pom/14/pom-14.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/kohsuke/pom/14/pom-14.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/kohsuke/pom/14/pom-14.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/kohsuke/pom/14/pom-14.pom (5.5 kB at 11 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.pom (2.4 kB at 3.7 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.pom (2.0 kB at 4.0 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.pom (2.0 kB at 3.2 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.pom (1.8 kB at 4.4 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.pom (3.8 kB at 9.7 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.pom
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.pom.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.pom (3.4 kB at 11 kB/s)
[INFO] HTTP/3+QUIC support is experimental and not suited for production use.
Downloading from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/args4j/args4j/2.33/args4j-2.33.jar (155 kB at 259 kB/s)
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.jar
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar
Downloading from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.jar
Downloading from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-jcl/6.1.0/spring-jcl-6.1.0.jar (25 kB at 18 kB/s)
Downloading from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-observation/1.12.0/micrometer-observation-1.12.0.jar (72 kB at 14 kB/s)
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.jar
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-core/6.1.0/spring-core-6.1.0.jar (1.9 MB at 349 kB/s)
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/io/micrometer/micrometer-commons/1.12.0/micrometer-commons-1.12.0.jar (47 kB at 8.5 kB/s)
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-beans/6.1.0/spring-beans-6.1.0.jar (873 kB at 114 kB/s)
[INFO] HTTP/3.0 request done, method=GET, resp status=200, url=https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar.sha1
Downloaded from my-maven: https://artipie:8091/my-maven-proxy/org/springframework/spring-web/6.1.0/spring-web-6.1.0.jar (1.9 MB at 239 kB/s)
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ maven-http3 ---
[INFO] skip non existing resourceDirectory /w/src/main/resources
[INFO] 
[INFO] --- compiler:3.11.0:compile (default-compile) @ maven-http3 ---
[INFO] No sources to compile
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ maven-http3 ---
[INFO] skip non existing resourceDirectory /w/src/test/resources
[INFO] 
[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ maven-http3 ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.1.2:test (default-test) @ maven-http3 ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jar:3.3.0:jar (default-jar) @ maven-http3 ---
[WARNING] JAR will be empty - no content was marked for inclusion!
[INFO] Building jar: /w/target/maven-http3-0.1.jar
[INFO] 
[INFO] --- install:3.1.1:install (default-install) @ maven-http3 ---
[INFO] Installing /w/pom.xml to /root/.m2/repository/com/example/maven-http3/0.1/maven-http3-0.1.pom
[INFO] Installing /w/target/maven-http3-0.1.jar to /root/.m2/repository/com/example/maven-http3/0.1/maven-http3-0.1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.494 s
[INFO] Finished at: 2023-12-13T06:58:40Z
[INFO] ------------------------------------------------------------------------

```